### PR TITLE
Build the benchmark program with release mode (`-O2 -DNDEBUG`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /results
+
+# The binary
+HATtrickBench
+src/*.o
+

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,35 @@
 CC=g++
-CXXFLAGS=-c -std=c++2a
+
+CXXFLAGS=-c -std=c++2a -Wall -Werror \
+	-g -O2 -DNDEBUG # release mode
 LDFLAGS=-lodbc -pthread
 SRCS= src/DataGen.cpp src/DataSrc.cpp src/UserInput.cpp src/Driver.cpp \
-src/DBInit.cpp src/SQLDialect.cpp src/Barrier.cpp src/AnalyticalClient.cpp \
-src/TransactionalClient.cpp src/Workload.cpp src/Globals.cpp \
-src/GetFromDB.cpp src/HATtrickBench.cpp src/Results.cpp src/Frontier.cpp src/LinkedList.cpp
+	src/DBInit.cpp src/SQLDialect.cpp src/Barrier.cpp src/AnalyticalClient.cpp \
+	src/TransactionalClient.cpp src/Workload.cpp src/Globals.cpp \
+	src/GetFromDB.cpp src/HATtrickBench.cpp src/Results.cpp src/Frontier.cpp src/LinkedList.cpp
+
+INC=
+LIB=
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	INC += -I$(shell brew --prefix unixodbc)/include
+	LIB += -L$(shell brew --prefix unixodbc)/lib
+endif
+
 OBJECTS=$(SRCS:.cpp=.o)
+
 EXECUTABLE=HATtrickBench
 
 all: $(SRCS) $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS)
-	$(CC) $(OBJECTS) -o $@ $(LDFLAGS)
+	$(CC) $(OBJECTS) $(LIB) -o $@ $(LDFLAGS)
 
 .cpp.o:
-	$(CC) $(CXXFLAGS) $< -o $@
+	$(CC) $(CXXFLAGS) $(INC) $< -o $@
 
+.PHONY: clean
 clean:
-	rm HATtrickBench
-	rm src/*.o
+	rm $(OBJECTS) $(EXECUTABLE)
 	rm -rf results

--- a/src/Driver.cpp
+++ b/src/Driver.cpp
@@ -9,7 +9,7 @@ void Driver::extract_error(const char* fn, SQLHANDLE& handle, SQLSMALLINT type){
     SQLCHAR text[256]= {0};
     SQLSMALLINT len;
     SQLRETURN ret;
-    cout << "\nThe driver reported the following diagnostics whilst running " << fn << "\n\n";
+    cout << "\nThe driver reported the following diagnostics while running " << fn << "\n\n";
     do
     {
         ret = SQLGetDiagRec(type, handle, ++i, state, &native, text, sizeof(text), &len );

--- a/src/Frontier.cpp
+++ b/src/Frontier.cpp
@@ -145,10 +145,8 @@ void Frontier::findFrontier(){
     int max_ac = getMaxAC();
     int max_tc = getMaxTC();
     int tc, ac = 0;
-    double ratios[6] = {0, 0.1, 0.2, 0.5, 0.8, 1};
-    const int ratios_num = sizeof(ratios)/sizeof(ratios[0]);
-    double t_throughputs[ratios_num*ratios_num] = {0.0};
-    double a_throughputs[ratios_num*ratios_num] = {0.0};
+    constexpr double ratios[6] = {0, 0.1, 0.2, 0.5, 0.8, 1};
+    constexpr int ratios_num = sizeof(ratios)/sizeof(ratios[0]);
     for(int i=0; i<ratios_num; i++){
     	    for(int j=0; j<ratios_num; j++){
 	        if(floor(ratios[i]*max_tc) == 0 && ratios[i]!=0)

--- a/src/Frontier.cpp
+++ b/src/Frontier.cpp
@@ -146,7 +146,7 @@ void Frontier::findFrontier(){
     int max_tc = getMaxTC();
     int tc, ac = 0;
     double ratios[6] = {0, 0.1, 0.2, 0.5, 0.8, 1};
-    int ratios_num = sizeof(ratios)/sizeof(ratios[0]);
+    const int ratios_num = sizeof(ratios)/sizeof(ratios[0]);
     double t_throughputs[ratios_num*ratios_num] = {0.0};
     double a_throughputs[ratios_num*ratios_num] = {0.0};
     for(int i=0; i<ratios_num; i++){

--- a/src/Frontier.h
+++ b/src/Frontier.h
@@ -21,9 +21,6 @@ class Frontier{
 private:
     int max_tc = 0;
     int max_ac = 0;
-    int num_of_ratios = 0;
-    vector<double> t_throughputs;
-    vector<double> a_throughputs;
 public:
     void deleteTuples();
     void createFreshnessTable(int& tc);

--- a/src/Frontier.h
+++ b/src/Frontier.h
@@ -1,5 +1,5 @@
 #ifndef HATTRICKBENCH_FRONTIER_H
-#define HATTRICKBENCH_FR0NTIER_H
+#define HATTRICKBENCH_FRONTIER_H
 #include "Driver.h"
 #include "Barrier.h"
 #include "Workload.h"

--- a/src/Results.h
+++ b/src/Results.h
@@ -4,7 +4,6 @@
 #include "AnalyticalClient.h"
 #include "TransactionalClient.h"
 #include <iostream>
-#include <bits/stdc++.h>
 #include <math.h>
 using namespace std;
 

--- a/src/TransactionalClient.cpp
+++ b/src/TransactionalClient.cpp
@@ -1,5 +1,6 @@
 
 #include "TransactionalClient.h"
+#include <string>
 
 TransactionalClient::TransactionalClient(){}
 
@@ -173,7 +174,8 @@ int TransactionalClient::NewOrderTransactionSS(SQLHDBC& dbc){
     string ordpriority = DataSrc::getOrdPriority(DataSrc::uniformIntDist(0,4));
     char* ord =  &ordpriority[0];
     int shippriority = DataSrc::uniformIntDist(0,1);
-    char* shipp = &to_string(shippriority)[0];
+    string shippriority_str = to_string(shippriority);
+    char* shipp = const_cast<char *>(shippriority_str.data());
     int quantity = DataSrc::uniformIntDist(1, 50);
     double extendedprice = quantity;  // TODO:  multiply with p_price in the store procedure;
     int discount =  DataSrc::uniformIntDist(0, 10);
@@ -278,7 +280,8 @@ void TransactionalClient::NewOrderTransaction(SQLHDBC& dbc){
         ordpriority = DataSrc::getOrdPriority(DataSrc::uniformIntDist(0,4));
         char* ord =  &ordpriority[0];
         shippriority = DataSrc::uniformIntDist(0,1);
-        char* shipp = &to_string(shippriority)[0];
+        string shippriority_str = to_string(shippriority);
+        char* shipp = const_cast<char *>(shippriority_str.data());
         quantity = DataSrc::uniformIntDist(1, 50);
         extendedprice = quantity * p_price;
         discount =  DataSrc::uniformIntDist(0, 10);

--- a/src/TransactionalClient.h
+++ b/src/TransactionalClient.h
@@ -22,7 +22,6 @@ private:
     SQLHSTMT freshStmt = 0;
     int clientNum = 0;              
     vector<vector<double>> latencyVector = vector<vector<double>>(3);    // history of response time for the 3 transactions
-    int txn_num[3] = {0};           // number of txns executed from each category
     int localCounter = 0;           // local counter of the transactions that the current client is running 
 public:
     TransactionalClient();

--- a/src/Workload.cpp
+++ b/src/Workload.cpp
@@ -49,7 +49,7 @@ void Workload::AnalyticalStream(AnalyticalClient* aClient, Globals* g){
 }
 
 void Workload::TransactionalStreamPS(TransactionalClient* tClient, Globals* g, SQLHDBC& dbc){
-    int p, ret_no;
+    int p;
     int loOrderKey;
     chrono::steady_clock::time_point startTime;
     chrono::high_resolution_clock::time_point  execTimeStart;


### PR DESCRIPTION
## Changes
* Add `-O2 -DNDEBUG` to `CXXFLAGS` to make the benchmark program run under optimized mode
* Remove some unused variables
* Fix building the HATtrick benchmark program under clang 13
* Add the binary output files into `.gitignore`

Verified that the program can be built under
* g++ (GCC) 9.2.0
* clang version 13.0.0